### PR TITLE
Update go version used in GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,16 +3,19 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.19", "1.20", "1.21"]
+
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION


The go version specified currently (1.15) is not supported anymore.
