### PR TITLE
GitHub Actions: use mlugg/setup-zig action

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -17,9 +17,9 @@ jobs:
       with:
         go-version: "1.22"
 
-    - uses: goto-bus-stop/setup-zig@v2
+    - uses: mlugg/setup-zig@v1
       with:
-        version: "0.11.0"
+        version: "0.13.0"
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
The previous action we used (goto-bus-stop/setup-zig) is deprecated in favor of this new action.

Also updates the zig version to the latest stable version (0.13.0)