### PR TITLE
misc refactors

### DIFF
--- a/data/interval.go
+++ b/data/interval.go
@@ -136,7 +136,7 @@ func (interval Interval) String() string {
 // IntervalsToStrings converts a slice of Interval structs to a slice of the corresponding timewarrior interval strings
 // Important: the LastModified information is not contained in the string representation
 func IntervalsToStrings(intervals []Interval) []string {
-	result := make([]string, len(intervals), len(intervals))
+	result := make([]string, len(intervals))
 
 	for i, element := range intervals {
 		result[i] = element.Serialize()

--- a/data/interval_test.go
+++ b/data/interval_test.go
@@ -18,9 +18,10 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package data
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestInterval_JSONConversion(t *testing.T) {
@@ -56,7 +57,7 @@ func TestInterval_Serialize(t *testing.T) {
 
 func TestIntervalsToStrings(t *testing.T) {
 	loc, _ := time.LoadLocation("UTC")
-	testData := make([]Interval, 3, 3)
+	testData := make([]Interval, 3)
 	testData[0] = Interval{
 		Start: time.Date(2020, 11, 25, 9, 39, 10, 0, loc),
 		End:   time.Date(2020, 11, 25, 9, 39, 43, 0, loc),

--- a/data/parse_test.go
+++ b/data/parse_test.go
@@ -17,9 +17,10 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package data
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseJSON(t *testing.T) {

--- a/storage/ephemeral.go
+++ b/storage/ephemeral.go
@@ -18,8 +18,9 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package storage
 
 import (
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"log"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 )
 
 // Ephemeral represents storage of user interval data.

--- a/storage/ephemeral_test.go
+++ b/storage/ephemeral_test.go
@@ -18,10 +18,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package storage
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 )
 
 func TestEphemeralStorage(t *testing.T) {

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -21,11 +21,12 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+	"log"
+
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/timewarrior-synchronize/timew-sync-server/data"
-	"log"
 )
 
 //go:embed migrations/*.sql

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -18,10 +18,11 @@ package storage
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -19,9 +19,10 @@ package storage
 
 import (
 	"encoding/json"
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"log"
 	"time"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 )
 
 // A UserId represents a unique ID assigned to each user of the
@@ -37,7 +38,7 @@ type IntervalKey struct {
 
 // ConvertToKeys converts a slice of data.Interval to a slice of IntervalKey
 func ConvertToKeys(data []data.Interval) []IntervalKey {
-	result := make([]IntervalKey, len(data), len(data))
+	result := make([]IntervalKey, len(data))
 	for i, interval := range data {
 		result[i] = IntervalToKey(interval)
 	}
@@ -46,7 +47,7 @@ func ConvertToKeys(data []data.Interval) []IntervalKey {
 
 // ConvertToIntervals converts a slice of IntervalKey to a slice of data.Interval
 func ConvertToIntervals(keys []IntervalKey) []data.Interval {
-	result := make([]data.Interval, len(keys), len(keys))
+	result := make([]data.Interval, len(keys))
 	for i, key := range keys {
 		result[i] = KeyToInterval(key)
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -17,10 +17,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package storage
 
 import (
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 )
 
 func TestIntervalToKey(t *testing.T) {

--- a/sync/algo.go
+++ b/sync/algo.go
@@ -19,14 +19,15 @@ package sync
 
 import (
 	"fmt"
+
 	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"github.com/timewarrior-synchronize/timew-sync-server/storage"
 )
 
 // Sync updates the stored state in passed storage.Storage for the user issuing the sync request. If something fails it
-//tries to restore the state
+// tries to restore the state
 // prior to the syncRequest. This is not always possible though. The error message denotes whether restoring state was
-//successful.
+// successful.
 // Later atomicity should be guaranteed by storage.
 // Iff no errors occur Sync returns the synced interval data of the user issuing the sync request.
 func Sync(syncRequest data.SyncRequest, store storage.Storage) ([]data.Interval, bool, error) {

--- a/sync/algo_test.go
+++ b/sync/algo_test.go
@@ -17,20 +17,18 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package sync
 
 import (
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
-	"github.com/timewarrior-synchronize/timew-sync-server/storage"
+	"slices"
+
 	"testing"
 	"time"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
+	"github.com/timewarrior-synchronize/timew-sync-server/storage"
 )
 
 func contains(slice []data.Interval, interval data.Interval) bool {
 	keySlice := storage.ConvertToKeys(slice)
-	for _, a := range keySlice {
-		if a == storage.IntervalToKey(interval) {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(keySlice, storage.IntervalToKey(interval))
 }
 
 func TestSync(t *testing.T) {

--- a/sync/auth.go
+++ b/sync/auth.go
@@ -19,14 +19,15 @@ package sync
 
 import (
 	"fmt"
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"log"
 	"net/http"
 	"path/filepath"
 	"time"
+
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
 )
 
 // Authenticate returns true iff the JWT specified in the HTTP requests' Bearer token was signed by the correct user.

--- a/sync/auth_test.go
+++ b/sync/auth_test.go
@@ -20,12 +20,13 @@ package sync
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/lestrrat-go/jwx/jwt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/jwt"
 )
 
 func TestAuthenticateWithKeySet_positive(t *testing.T) {

--- a/sync/conflict.go
+++ b/sync/conflict.go
@@ -19,9 +19,10 @@ package sync
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"github.com/timewarrior-synchronize/timew-sync-server/storage"
-	"sort"
 )
 
 // SolveConflict merges overlapping intervals of given user.

--- a/sync/conflict_test.go
+++ b/sync/conflict_test.go
@@ -18,11 +18,12 @@ package sync
 
 import (
 	"fmt"
-	"github.com/timewarrior-synchronize/timew-sync-server/data"
-	"github.com/timewarrior-synchronize/timew-sync-server/storage"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/data"
+	"github.com/timewarrior-synchronize/timew-sync-server/storage"
 )
 
 func elementwiseEqual(aSlice []data.Interval, bSlice []data.Interval) bool {

--- a/sync/handle.go
+++ b/sync/handle.go
@@ -18,13 +18,13 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package sync
 
 import (
+	"io"
+	"log"
+	"net/http"
+
 	_ "github.com/lestrrat-go/jwx"
 	"github.com/timewarrior-synchronize/timew-sync-server/data"
 	"github.com/timewarrior-synchronize/timew-sync-server/storage"
-	"io"
-	"io/ioutil"
-	"log"
-	"net/http"
 )
 
 var PublicKeyLocation string
@@ -32,7 +32,7 @@ var PublicKeyLocation string
 // HandleSyncRequest receives sync requests and starts the sync
 // process with the received data.
 func HandleSyncRequest(w http.ResponseWriter, req *http.Request, noAuth bool) {
-	requestBody, err := ioutil.ReadAll(req.Body)
+	requestBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Printf("Error reading HTTP request, ignoring request: %v", err)
 		return

--- a/sync/response_test.go
+++ b/sync/response_test.go
@@ -17,8 +17,9 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 package sync
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestToString(t *testing.T) {

--- a/sync/user_management.go
+++ b/sync/user_management.go
@@ -19,9 +19,7 @@ package sync
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -31,7 +29,7 @@ import (
 // GetUsedUserIDs returns a map containing every user id with an existing file [user id]_keys
 // in PublicKeyLocation directory
 func GetUsedUserIDs() map[int64]bool {
-	files, err := ioutil.ReadDir(PublicKeyLocation)
+	files, err := os.ReadDir(PublicKeyLocation)
 	if err != nil {
 		log.Fatal("Error accessing keys-location directory")
 	}
@@ -56,7 +54,7 @@ func GetUsedUserIDs() map[int64]bool {
 // GetFreeUserID returns the smallest valid unused user id
 func GetFreeUserID() int64 {
 	used := GetUsedUserIDs()
-	for i := int64(0); i <= math.MaxInt64; i++ {
+	for i := int64(0); i > 0; i++ {
 		if !used[i] {
 			return i
 		}
@@ -67,7 +65,7 @@ func GetFreeUserID() int64 {
 
 // ReadKey reads the key from a file
 func ReadKey(path string) string {
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("Error reading key file at %v", path)
 	}


### PR DESCRIPTION
- organize imports
- remove redundant capacity arguments to `make`
- use `slices.Contains`
- remove uses of deprecated `ioutil` pkg
- fix for loop in `GetFreeUserID`