### PR TITLE
ci: use major verson for softprops/action-gh-release

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -10,29 +10,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - name: Set up Go
-      uses: actions/setup-go@v7
-      with:
-        go-version: "1.25"
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.25"
 
-    - uses: mlugg/setup-zig@v2
-      with:
-        version: "0.13.0"
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: "0.13.0"
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...
 
-    - name: Build x86_64 Linux
-      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-musl" go build -o timew-sync-server-x86_64-linux
+      - name: Build x86_64 Linux
+        run: GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-musl" go build -o timew-sync-server-x86_64-linux
 
-    - name: Build aarch64 Linux
-      run: GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC="zig cc -target aarch64-linux-musl" go build -o timew-sync-server-aarch64-linux
+      - name: Build aarch64 Linux
+        run: GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC="zig cc -target aarch64-linux-musl" go build -o timew-sync-server-aarch64-linux
 
-    - name: Release
-      uses: softprops/action-gh-release@v3.0.2
-      with:
-        files: |
-          timew-sync-server-x86_64-linux
-          timew-sync-server-aarch64-linux
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            timew-sync-server-x86_64-linux
+            timew-sync-server-aarch64-linux

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - name: Set up Go
-      uses: actions/setup-go@v7
-      with:
-        go-version: "1.25"
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.25"
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...
 
-    - name: Build x86_64 macOS
-      run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o timew-sync-server-x86_64-macos
+      - name: Build x86_64 macOS
+        run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o timew-sync-server-x86_64-macos
 
-    - name: Build aarch64 macOS
-      run: GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -o timew-sync-server-aarch64-macos
+      - name: Build aarch64 macOS
+        run: GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -o timew-sync-server-aarch64-macos
 
-    - name: Release
-      uses: softprops/action-gh-release@v3.0.2
-      with:
-        files: |
-          timew-sync-server-x86_64-macos
-          timew-sync-server-aarch64-macos
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            timew-sync-server-x86_64-macos
+            timew-sync-server-aarch64-macos


### PR DESCRIPTION
This reduces the number of dependabot prs