### PR TITLE
fix: harden HTTP server and request handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,23 +21,27 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"github.com/timewarrior-synchronize/timew-sync-server/storage"
-	"github.com/timewarrior-synchronize/timew-sync-server/sync"
 	"log"
 	"net/http"
 	"os"
+	"time"
+
+	"github.com/timewarrior-synchronize/timew-sync-server/storage"
+	"github.com/timewarrior-synchronize/timew-sync-server/sync"
 
 	_ "github.com/mattn/go-sqlite3"
 )
 
-var versionFlag bool
-var configFilePath string
-var portNumber int
-var keyDirectoryPath string
-var dbPath string
-var noAuth bool
-var sourcePath string
-var userID int64
+var (
+	versionFlag      bool
+	configFilePath   string
+	portNumber       int
+	keyDirectoryPath string
+	dbPath           string
+	noAuth           bool
+	sourcePath       string
+	userID           int64
+)
 
 func main() {
 	startCmd := flag.NewFlagSet("start", flag.ExitOnError)
@@ -99,14 +103,21 @@ func main() {
 		sync.HandleSyncRequest(w, req, noAuth)
 	}
 	healthHandler := func(w http.ResponseWriter, req *http.Request) {
-                fmt.Fprint(w, "OK")
+		fmt.Fprint(w, "OK")
 	}
 
 	http.HandleFunc("/api/sync", syncHandler)
 	http.HandleFunc("/api/health", healthHandler)
 
 	log.Printf("Listening on Port %v", portNumber)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", portNumber), nil))
+	srv := &http.Server{
+		Addr:              fmt.Sprintf(":%v", portNumber),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 // Subcommand for adding a new user

--- a/sync/handle.go
+++ b/sync/handle.go
@@ -32,6 +32,11 @@ var PublicKeyLocation string
 // HandleSyncRequest receives sync requests and starts the sync
 // process with the received data.
 func HandleSyncRequest(w http.ResponseWriter, req *http.Request, noAuth bool) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	requestBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Printf("Error reading HTTP request, ignoring request: %v", err)

--- a/sync/user_management.go
+++ b/sync/user_management.go
@@ -95,7 +95,6 @@ func AddKey(userID int64, key string) {
 		key = "\n" + key
 	}
 	if _, err = destFile.WriteString(key); err != nil {
-		destFile.Close()
 		log.Fatalf("Error adding key. Unable to write to key file with user id %v", userID)
 	}
 }


### PR DESCRIPTION
This PR hardens the HTTP server against common abuse scenarios and tightens request handling on the sync endpoint.

## Changes

- Configure explicit server timeouts (`main.go`): Replace the bare `http.ListenAndServe` call with an `http.Server` configured with `ReadHeaderTimeout` (10s), `ReadTimeout` (30s), `WriteTimeout` (60s), and `IdleTimeout` (120s). This mitigates Slowloris-style attacks and prevents connections from exhausting server resources by staying open indefinitely.
- Restrict `/api/sync` to POST (`sync/handle.go`): The sync handler now rejects non-POST requests with `405 Method Not Allowed` instead of attempting to parse them as sync payloads.
- Remove redundant file close (`sync/user_management.go`): Drop the explicit `destFile.Close()` in the error path of `AddKey`; `log.Fatalf` terminates the process anyway, and the file handle is already managed by the deferred close.
- Minor cleanup: Grouped `var` declarations, fixed import ordering, and corrected indentation of the health handler.

## Motivation

Running with Go's default `http.Server` settings means no timeouts at all, leaving the server vulnerable to slow-client resource exhaustion. Additionally, the sync endpoint accepted any HTTP method, which made request handling less strict than necessary. These changes improve robustness without altering the sync protocol or API behavior for legitimate clients.

## Testing

- Verified the server starts and responds on `/api/health` as before.
- Confirmed `GET /api/sync` now returns `405 Method Not Allowed`, while well-formed `POST` requests continue to sync successfully.
